### PR TITLE
Fixes #4: Fix pushing pages without a module

### DIFF
--- a/types/skuid.go
+++ b/types/skuid.go
@@ -104,8 +104,11 @@ func FilterByModule(dir, moduleFilter string) ([]string, error) {
 
 	filter := &bytes.Buffer{}
 
-	filter.WriteString(moduleFilter)
-	filter.WriteString("_*")
+	if moduleFilter != "" {
+		filter.WriteString(moduleFilter + "_")
+	}
+
+	filter.WriteString("*")
 
 	pattern := filepath.Join(dir, filter.String())
 	return filepath.Glob(pattern)


### PR DESCRIPTION
Pages without a module were written with a filename that did not start
with an underscore which means you could not use the directory flag to
push all pages outside of a module. This fix will do everything in the
directory by default, with the added module filter is available.