### PR TITLE
[PLIN-1668] Standardize the paths present within the created archive

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -34,16 +34,20 @@ var deployCmd = &cobra.Command{
 
 		var targetDirFriendly string
 
-		// If target directory is not provided,
-		// use the current directory's contents
-		if targetDir == "" {
-			targetDir = "."
-			targetDirFriendly, err = filepath.Abs(filepath.Dir(os.Args[0]))
+		// If target directory is provided,
+		// switch to that target directory and later switch back.
+		if targetDir != "" {
+			os.Chdir(targetDir)
+			pwd, err := os.Getwd()
 			if err != nil {
 				log.Fatal(err)
 			}
-		} else {
-			targetDirFriendly = targetDir
+			defer os.Chdir(pwd)
+		}
+		targetDir = "."
+		targetDirFriendly, err = filepath.Abs(filepath.Dir(os.Args[0]))
+		if err != nil {
+			log.Fatal(err)
 		}
 
 		if verbose {


### PR DESCRIPTION
https://skuidify.atlassian.net/browse/PLIN-1668

Before this change, we would add the target directory path as a prefix to all files placed in the archive. Once the archive file is received at the deployment handler, the files with these prefixes were not being identified as metadata since the handler expects a standard set of metadata artifacts (`datasources/`, `pages/`, etc).

Now we switch into the target directory while creating the archive so that the target directory path is not added as a prefix within the archive itself. We then defer changing back to the execution directory as a safeguard.