### PR TITLE
CORE-2156: Pull Command No Longer Requires Page or Module Params

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -45,7 +45,7 @@ var pullCmd = &cobra.Command{
 		//build the module and name query paramaters
 		query := url.Values{}
 
-		if noModule && module == "" {
+		if noModule {
 			query.Add("nomodule", strconv.FormatBool(noModule))
 		}
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var noModule bool
+
 // pullCmd represents the pull command
 var pullCmd = &cobra.Command{
 	Use:   "pull",
@@ -43,6 +45,10 @@ var pullCmd = &cobra.Command{
 		//build the module and name query paramaters
 		query := url.Values{}
 
+		if noModule && module == "" && page == "" {
+			query.Add("nomodule", strconv.FormatBool(noModule))
+		}
+
 		if module != "" {
 			query.Add("module", module)
 		}
@@ -50,7 +56,7 @@ var pullCmd = &cobra.Command{
 		if page != "" {
 			query.Add("page", page)
 		}
-
+		
 		//query the API for all pages in the requested module
 		result, err := api.Connection.Get("/skuid/api/v1/pages", query)
 
@@ -89,5 +95,7 @@ var pullCmd = &cobra.Command{
 }
 
 func init() {
+	pullCmd.Flags().BoolVarP(&noModule, "no-module", "", false, "Retrieve only those pages that do not have a module")
 	RootCmd.AddCommand(pullCmd)
+
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -45,7 +45,7 @@ var pullCmd = &cobra.Command{
 		//build the module and name query paramaters
 		query := url.Values{}
 
-		if noModule && module == "" && page == "" {
+		if noModule && module == "" {
 			query.Add("nomodule", strconv.FormatBool(noModule))
 		}
 


### PR DESCRIPTION
## Summary

As of 11.2, the page `pull` API currently requires that a page name or module name be provided. This should not be the case. You should be able to request all pages or pages without a module.

## JIRA

[CORE_2156](https://skuidify.atlassian.net/browse/CORE-2156)