### PR TITLE
Fix bugs with errors

### DIFF
--- a/httperror/httperror.go
+++ b/httperror/httperror.go
@@ -12,14 +12,12 @@ func New(status string, body io.Reader) error {
 	var httpError HTTPError
 	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
-		fmt.Println("Failed Reading")
 		return fmt.Errorf("%v - %v", err.Error(), "Could not parse error message")
 	}
 	bodyString := string(bodyBytes)
 	// Attempt to parse the body
 	err = json.Unmarshal(bodyBytes, &httpError)
 	if err != nil {
-		fmt.Println("Failed Parsing")
 		return fmt.Errorf("%v - %v", err.Error(), bodyString)
 	}
 

--- a/httperror/httperror.go
+++ b/httperror/httperror.go
@@ -12,14 +12,18 @@ func New(status string, body io.Reader) error {
 	var httpError HTTPError
 	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
+		fmt.Println("Failed Reading")
 		return fmt.Errorf("%v - %v", err.Error(), "Could not parse error message")
 	}
+	bodyString := string(bodyBytes)
 	// Attempt to parse the body
 	err = json.Unmarshal(bodyBytes, &httpError)
 	if err != nil {
-		return fmt.Errorf("%v - %v", err.Error(), string(bodyBytes))
+		fmt.Println("Failed Parsing")
+		return fmt.Errorf("%v - %v", err.Error(), bodyString)
 	}
 
+	httpError.Body = bodyString
 	httpError.Status = status
 
 	return &httpError
@@ -36,7 +40,13 @@ type HTTPError struct {
 
 func (e *HTTPError) Error() string {
 	if e.ParsedError != "" && e.ParsedMessage != "" {
-		return fmt.Sprintf("%v - %v - %v", e.StatusCode, e.ParsedError, e.ParsedMessage)
+		return fmt.Sprintf("%v - %v - %v", e.Status, e.ParsedError, e.ParsedMessage)
 	}
-	return fmt.Sprintf("%v - %v", e.StatusCode, e.Body)
+	if e.ParsedError != "" {
+		return fmt.Sprintf("%v - %v", e.Status, e.ParsedError)
+	}
+	if e.ParsedMessage != "" {
+		return fmt.Sprintf("%v - %v", e.Status, e.ParsedMessage)
+	}
+	return fmt.Sprintf("%v - %v", e.Status, e.Body)
 }


### PR DESCRIPTION
Errors in the CLI were not returning correctly from warden because warden doesn't always populate the "error" property in its JSON error responses. This improves the error display by not requiring that "error" and "message" be set to display a pretty error.