### PR TITLE
fix(login): Don't attempt to login without username and password

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,6 +41,8 @@ var deployCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		deployStart := time.Now()
+
 		var targetDirFriendly string
 
 		// If target directory is provided,
@@ -83,7 +85,14 @@ var deployCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Success! Deployed metadata to Skuid Site.")
+		successMessage := "Successfully deployed metadata to Skuid Site"
+
+		if verbose {
+			fmt.Println(text.SuccessWithTime(successMessage, deployStart))
+		} else {
+			fmt.Println(successMessage + ".")
+		}
+		
 	},
 }
 

--- a/cmd/retrieve.go
+++ b/cmd/retrieve.go
@@ -40,6 +40,8 @@ var retrieveCmd = &cobra.Command{
 			verbose,
 		)
 
+		retrieveStart := time.Now()
+
 		if err != nil {
 			fmt.Println(text.PrettyError("Error logging in to Skuid site", err))
 			os.Exit(1)
@@ -60,6 +62,14 @@ var retrieveCmd = &cobra.Command{
 		err = writeResultsToDisk(results)
 		if err != nil {
 			fmt.Println(text.PrettyError("Error writing results to disk", err))
+			os.Exit(1)
+		}
+
+		successMessage := "Successfully retrieved metadata from Skuid Site"
+		if verbose {
+			fmt.Println(text.SuccessWithTime(successMessage, retrieveStart))
+		} else {
+			fmt.Println(successMessage + ".")
 		}
 	},
 }
@@ -77,6 +87,7 @@ func getFriendlyURL(targetDir string) (string, error) {
 }
 
 func writeResultsToDisk(results []*io.ReadCloser) error {
+
 	// unzip the archive into the output directory
 	targetDirFriendly, err := getFriendlyURL(targetDir)
 	if err != nil {
@@ -120,7 +131,8 @@ func writeResultsToDisk(results []*io.ReadCloser) error {
 		}
 	}
 
-	fmt.Printf("Success! Results written to %s\n", targetDirFriendly)
+	fmt.Printf("Results written to %s\n", targetDirFriendly)
+
 	return nil
 }
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"net/http"
 	"net/url"
 	"strings"
@@ -49,9 +50,18 @@ func Login(host, username, password, apiVersion, metadataServiceProxy, dataServi
 
 	loginStart := time.Now()
 
+	if username == "" {
+		fmt.Println("No Username provided - login failed.")
+		os.Exit(1)
+	}
+
+	if password == "" {
+		fmt.Println("No Password provided - login failed.")
+		os.Exit(1)
+	}
+
 	if verbose {
 		fmt.Println(fmt.Sprintf("Logging in to Skuid Platform as user: %v\n%v", username, host))
-		fmt.Println("Password: " + password)
 		fmt.Println("API Version: " + apiVersion)
 	}
 


### PR DESCRIPTION
# Summary of Changes

- Don't attempt to login at all unless username and password are provided
- Never log password, even in verbose mode
- Add logging of time taken for deploy/retrieve in verbose mode