### PR TITLE
feat(params): Ensure universally required params exist, prepend https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= golang
 ARCH=amd64
 OS=darwin
 
-VERSION=0.3.7
+VERSION=0.3.8
 
 .PHONY: setup fmt vendored
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To quickly install the application, copy and paste the following commands in the
 # On a macOS machine? Use this:
 wget https://github.com/skuid/skuid/releases/download/3/skuid_darwin_amd64 -O skuid
 # On a Linux machine? Use this instead:
-# wget https://github.com/skuid/skuid/releases/download/0.3.7/skuid_linux_amd64 -O skuid
+# wget https://github.com/skuid/skuid/releases/download/0.3.8/skuid_linux_amd64 -O skuid
 # Give the skuid application the permissions it needs to run
 chmod +x skuid
 # Move the skuid application to a folder where it can be used easily

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/skuid/skuid/version"
 	"github.com/spf13/cobra"
@@ -68,5 +69,26 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+
+	// Ensure we have universally-required parameters
+	if username == "" {
+		fmt.Println("No Username provided - request could not be performed.")
+		os.Exit(1)
+	}
+
+	if password == "" {
+		fmt.Println("No Password provided - request could not be performed.")
+		os.Exit(1)
+	}
+
+	if host == "" {
+		fmt.Println("No Host provided - request could not be performed.")
+		os.Exit(1)	
+	}
+
+	// Graciously handle an org/site host that does not start "https://"
+	if !strings.HasPrefix(host, "https://") {
+		host = "https://" + host
 	}
 }

--- a/force/force.go
+++ b/force/force.go
@@ -51,15 +51,16 @@ func Login(consumerKey string, consumerSecret string, instanceUrl string, userna
 }
 
 func (conn *RestConnection) Get(url string, query url.Values) (result []byte, err error) {
-	return conn.Query("GET", url, nil, query)
+	return conn.MakeRequest("GET", url, nil, query)
 }
 
 func (conn *RestConnection) Post(url string, payload interface{}) (result []byte, err error) {
-	return conn.Query("POST", url, payload, nil)
+	return conn.MakeRequest("POST", url, payload, nil)
 }
 
-// Query is executing a HTTP request
-func (conn *RestConnection) Query(method string, url string, payload interface{}, params url.Values) (result []byte, err error) {
+// Executes an HTTP Request against the Skuid Pages REST API
+func (conn *RestConnection) MakeRequest(method string, url string, payload interface{}, params url.Values) (result []byte, err error) {
+
 	endpoint := conn.InstanceUrl + "/services/apexrest" + url
 
 	if params != nil && len(params) != 0 {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"net/http"
 	"net/url"
 	"strings"
@@ -50,18 +49,8 @@ func Login(host, username, password, apiVersion, metadataServiceProxy, dataServi
 
 	loginStart := time.Now()
 
-	if username == "" {
-		fmt.Println("No Username provided - login failed.")
-		os.Exit(1)
-	}
-
-	if password == "" {
-		fmt.Println("No Password provided - login failed.")
-		os.Exit(1)
-	}
-
 	if verbose {
-		fmt.Println(fmt.Sprintf("Logging in to Skuid Platform as user: %v\n%v", username, host))
+		fmt.Println(fmt.Sprintf("Logging in to Skuid Platform as user: %v\n%v", username, host)) 
 		fmt.Println("API Version: " + apiVersion)
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Name of this version of Skuid CLI
-const Name = "0.3.7"
+const Name = "0.3.8"


### PR DESCRIPTION
- Ensure universally required params Host, Username, and Password are set before running any other commands, otherwise die immediately
- Prepends https:// to Host if necessary (Addresses #12, #20)
- Bump version to 0.3.8