### PR TITLE
fix(salesforce): Page Push/Pull does not send/retrieve API Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= golang
 ARCH=amd64
 OS=darwin
 
-VERSION=0.3.8
+VERSION=0.3.9
 
 .PHONY: setup fmt vendored
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To quickly install the application, copy and paste the following commands in the
 # On a macOS machine? Use this:
 wget https://github.com/skuid/skuid/releases/download/3/skuid_darwin_amd64 -O skuid
 # On a Linux machine? Use this instead:
-# wget https://github.com/skuid/skuid/releases/download/0.3.8/skuid_linux_amd64 -O skuid
+# wget https://github.com/skuid/skuid/releases/download/0.3.9/skuid_linux_amd64 -O skuid
 # Give the skuid application the permissions it needs to run
 chmod +x skuid
 # Move the skuid application to a folder where it can be used easily

--- a/types/skuid.go
+++ b/types/skuid.go
@@ -14,6 +14,7 @@ import (
 )
 
 type PullResponse struct {
+	APIVersion         string  `json:"apiVersion"`
 	Name               string  `json:"name"`
 	UniqueID           string  `json:"uniqueId"`
 	Type               string  `json:"type"`

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Name of this version of Skuid CLI
-const Name = "0.3.8"
+const Name = "0.3.9"


### PR DESCRIPTION
# Summary of Changes
- `skuid push` and `skuid pull` do not currently modify/retrieve a Page's API Version. This PR fixes that.

# JIRA
- Addresses CORE-2214